### PR TITLE
Fix heroku

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem 'jbuilder', '~> 2.5'
 # Use ActiveModel has_secure_password
 gem 'bcrypt', '~> 3.1.7'
 gem 'rqrcode', '~>0.10.1'
-
+gem 'aws-sdk-s3', '~> 1.0.0.rc2'
 # Use ActiveStorage variant
 # gem 'mini_magick', '~> 4.8'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,7 +57,7 @@ GEM
       sassc-rails (>= 2.0.0)
     builder (3.2.3)
     byebug (10.0.2)
-    capybara (3.12.0)
+    capybara (3.13.2)
       addressable
       mini_mime (>= 0.1.3)
       nokogiri (~> 1.8)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,21 @@ GEM
     arel (9.0.0)
     autoprefixer-rails (9.4.6)
       execjs
+    aws-eventstream (1.0.1)
+    aws-partitions (1.135.0)
+    aws-sdk-core (3.46.0)
+      aws-eventstream (~> 1.0)
+      aws-partitions (~> 1.0)
+      aws-sigv4 (~> 1.0)
+      jmespath (~> 1.0)
+    aws-sdk-kms (1.13.0)
+      aws-sdk-core (~> 3, >= 3.39.0)
+      aws-sigv4 (~> 1.0)
+    aws-sdk-s3 (1.0.0)
+      aws-sdk-core (~> 3)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.0)
+    aws-sigv4 (1.0.3)
     bcrypt (3.1.12)
     bindex (0.5.0)
     bootsnap (1.3.2)
@@ -94,6 +109,7 @@ GEM
     jbuilder (2.8.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
+    jmespath (1.4.0)
     jquery-rails (4.3.3)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -234,6 +250,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  aws-sdk-s3 (~> 1.0.0.rc2)
   bcrypt (~> 3.1.7)
   bootsnap (>= 1.1.0)
   bootstrap (~> 4.2.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -264,4 +264,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   2.0.1
+   1.16.6

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -27,7 +27,7 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
+  config.assets.compile = true
 
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -40,7 +40,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options)
-  config.active_storage.service = :local
+  config.active_storage.service = :amazon
   # Mount Action Cable outside main process or domain
   # config.action_cable.mount_path = nil
   # config.action_cable.url = 'wss://example.com/cable'

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -18,6 +18,7 @@ Rails.application.configure do
   # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).
   # config.require_master_key = true
 
+  
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -40,7 +40,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options)
-  config.active_storage.service = :amazon
+  config.active_storage.service = :local
   # Mount Action Cable outside main process or domain
   # config.action_cable.mount_path = nil
   # config.action_cable.url = 'wss://example.com/cable'

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -11,7 +11,7 @@ amazon:
   access_key_id: <%= ENV["AWS_ACCESS_KEY_ID"] %>
   secret_access_key: <%= ENV["AWS_SECRET_KEY"] %>
   region: eu-west-2
-  bucket: arn:aws:s3:::que-are-you-profile-images
+  bucket: que-are-you-profile-images
 
 # Use rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
 # amazon:


### PR DESCRIPTION
Fixed bugs - 
heroku buildpacks:add --index 1 heroku/nodejs (Should be the first buildpack to run)
heroku buildpacks:set heroku/ruby

Issue was, Heroku using bundler version 1.16 whilst our app used bundler 2.x , so I uninstalled bundler  and installed bundler version 1.1.5.2, which solved the issue.

Last issue and resolution:
aws-sdk gem missing and the fix was to just include it into the gemfile and run bundle.

I pushed this branch to heroku and works well.